### PR TITLE
 阅读界面添加“替换净化”菜单

### DIFF
--- a/app/src/main/java/com/monke/monkeybook/view/activity/ReadBookActivity.java
+++ b/app/src/main/java/com/monke/monkeybook/view/activity/ReadBookActivity.java
@@ -829,6 +829,9 @@ public class ReadBookActivity extends MBaseActivity<ReadBookContract.Presenter> 
             case R.id.action_book_info:
                 BookInfoActivity.startThis(this, mPresenter.getBookShelf().getNoteUrl());
                 break;
+            case R.id.action_replace_rule:
+                startActivity(new Intent(ReadBookActivity.this, ReplaceRuleActivity.class));
+                break;
             case android.R.id.home:
                 finish();
                 break;

--- a/app/src/main/res/menu/menu_book_read_activity.xml
+++ b/app/src/main/res/menu/menu_book_read_activity.xml
@@ -31,6 +31,12 @@
             app:showAsAction="ifRoom" />
 
         <item
+            android:id="@+id/action_replace_rule"
+            android:icon="@drawable/ic_find_replace"
+            android:title="@string/replace_rule_title"
+            app:showAsAction="ifRoom" />
+
+        <item
             android:id="@+id/action_copy_text"
             android:icon="@drawable/ic_settings_backup_restore"
             android:title="@string/copy_text"


### PR DESCRIPTION
这样看到有问题的地方可以直接修改替换规则，不用先回到主界面。