### PR TITLE
更新书籍地址模式

### DIFF
--- a/app/src/main/java/com/monke/monkeybook/model/content/BookList.java
+++ b/app/src/main/java/com/monke/monkeybook/model/content/BookList.java
@@ -42,6 +42,9 @@ class BookList {
                 assert response.body() != null;
                 Document doc = Jsoup.parse(response.body());
                 String bookUrlPattern = bookSourceBean.getRuleBookUrlPattern();
+                if (!isEmpty(bookUrlPattern) && !bookUrlPattern.endsWith(".*")) {
+                    bookUrlPattern += ".*";
+                }
                 if (!isEmpty(bookUrlPattern) && baseURI.matches(bookUrlPattern)
                         && !isEmpty(bookSourceBean.getRuleBookName()) && !isEmpty(bookSourceBean.getRuleBookLastChapter())) {
                     AnalyzeElement analyzeElement = new AnalyzeElement(doc, baseURI);


### PR DESCRIPTION
书籍地址可以只写前面一致的Pattern，末尾的 .* 可以不用写。