### PR TITLE
优化Xpath规则

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/model/analyzeRule/AnalyzeByXPath.java
+++ b/app/src/main/java/com/kunfei/bookshelf/model/analyzeRule/AnalyzeByXPath.java
@@ -4,7 +4,6 @@ import android.text.TextUtils;
 
 import com.kunfei.bookshelf.utils.NetworkUtil;
 
-import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.seimicrawler.xpath.JXDocument;
@@ -16,11 +15,14 @@ public class AnalyzeByXPath {
     private JXDocument jxDocument;
 
     public void parse(String doc) {
+        // 给表格标签添加完整的框架结构,否则会丢失表格标签;html标准不允许表格标签独立在table之外
+        if (doc.indexOf("<td>") == 0 || doc.indexOf("<td ") == 0) {
+            doc = "<tr>" + doc + "</tr>";
+        }
+        if (doc.indexOf("<tr>") == 0 || doc.indexOf("<tr ") == 0) {
+            doc = "<table>" + doc + "</table>";
+        }
         jxDocument = JXDocument.create(doc);
-    }
-
-    public void parse(Elements doc) {
-        jxDocument = new JXDocument(doc);
     }
 
     Elements getElements(String xPath) {
@@ -90,8 +92,7 @@ public class AnalyzeByXPath {
         List<Object> objects = jxDocument.sel(xPath);
         for (Object object : objects) {
             if (object instanceof String) {
-                result = (String)object;
-                if(result != null) result = result.replaceAll("^,|,$","");// 移除Xpath匹配结果首尾多余的逗号
+                result = (String) object;
                 stringList.add(result);
             }
         }
@@ -105,11 +106,11 @@ public class AnalyzeByXPath {
             result = ((Element) object).html()
                     .replaceAll("(?i)<(br[\\s/]*|p.*?|div.*?|/p|/div)>", "\n")
                     .replaceAll("<.*?>", "")
-                    .replaceAll("&nbsp;","")            // 删除空白转义符
-                    .replaceAll("[\\n*\\s*]+","\n　　"); // 移除空行,并增加段前缩进2个汉字
+                    .replaceAll("&nbsp;", "")            // 删除空白转义符
+                    .replaceAll("[\\n*\\s*]+", "\n　　"); // 移除空行,并增加段前缩进2个汉字
         } else {
             result = (String) object;
-            if(result != null) result = result.replaceAll("^,|,$","");// 移除Xpath匹配结果首尾多余的逗号
+            if (result != null) result = result.replaceAll("^,|,$", "");// 移除Xpath匹配结果首尾多余的逗号
         }
         if (!TextUtils.isEmpty(baseUrl)) {   // 获取绝对地址放到Xpath结果处理之后,防止Xpath匹配的多余逗号干扰Url的识别.
             result = NetworkUtil.getAbsoluteURL(baseUrl, result);

--- a/app/src/main/java/com/kunfei/bookshelf/model/content/BookList.java
+++ b/app/src/main/java/com/kunfei/bookshelf/model/content/BookList.java
@@ -78,6 +78,9 @@ class BookList {
                     collections = analyzer.getElements(bookSourceBean.getRuleSearchList().substring(1));
                 } else {
                     collections = analyzer.getElements(bookSourceBean.getRuleSearchList());
+                    if(collections.size() == 0){// 搜索列表为空时,尝试以当前网页为列表结果(用于处理搜索结果为书籍简介页的情况)
+                        collections = analyzer.getElements("//head/..");
+                    }
                 }
                 if (collections.size() == 0 && !e.isDisposed()) {
                     e.onError(new Throwable("搜索列表为空"));
@@ -100,6 +103,25 @@ class BookList {
                         String resultUrl = analyzer.getString(bookSourceBean.getRuleSearchNoteUrl(), baseUrl);
                         item.setNoteUrl(isEmpty(resultUrl) ? baseUrl : resultUrl);
                         books.add(item);
+                    }
+                    else
+                    {// 搜索结果为书籍简介页时,直接以书籍简介页规则获取信息
+                        bookName = analyzer.getString(bookSourceBean.getRuleBookName());
+                        if(TextUtils.isEmpty(bookName)){
+                            e.onError(new Throwable("搜索列表为空"));
+                            return;
+                        }
+                        item.setTag(tag);
+                        item.setOrigin(name);
+                        item.setName(bookName);
+                        item.setAuthor(FormatWebText.getAuthor(analyzer.getString(bookSourceBean.getRuleBookAuthor())));
+                        item.setKind(StringUtils.join(",", analyzer.getStringList(bookSourceBean.getRuleBookKind())));
+                        item.setLastChapter(analyzer.getString(bookSourceBean.getRuleBookLastChapter()));
+                        item.setCoverUrl(analyzer.getString(bookSourceBean.getRuleCoverUrl(), baseUrl));
+                        item.setIntroduce(analyzer.getString(bookSourceBean.getRuleIntroduce()));
+                        item.setNoteUrl(baseUrl);
+                        books.add(item);
+                        break;
                     }
                 }
                 if (books.size() > 1 && reverse) {


### PR DESCRIPTION
1.优化Table表格结构标签元素的选择结果,补全Table结构,否则会因为html标准丢失独立于table结构以外的tr和td标签.
2.删除XPath匹配规则的 "," 逗号过滤代码,因为JsoupXpath库已经修复了这个BUG.