### PR TITLE
fix SourceDebug variable missing bug

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/help/BookshelfHelp.java
+++ b/app/src/main/java/com/kunfei/bookshelf/help/BookshelfHelp.java
@@ -363,6 +363,7 @@ public class BookshelfHelp {
         bookInfo.setIntroduce(searchBookBean.getIntroduce());
         bookInfo.setChapterUrl(searchBookBean.getChapterUrl());
         bookShelfBean.setBookInfoBean(bookInfo);
+        bookShelfBean.setVariable(searchBookBean.getVariable());
         return bookShelfBean;
     }
 


### PR DESCRIPTION
修复【书源调试】时，variable 没有从搜索结果(searchBookBean)传值到书实体(bookShelfBean)的bug。