### PR TITLE
优化书籍详情url正则

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/presenter/MainPresenter.java
+++ b/app/src/main/java/com/kunfei/bookshelf/presenter/MainPresenter.java
@@ -28,6 +28,8 @@ import com.kunfei.bookshelf.presenter.contract.MainContract;
 import com.kunfei.bookshelf.utils.RxUtils;
 import com.kunfei.bookshelf.utils.StringUtils;
 
+import java.net.URL;
+
 import io.reactivex.Observable;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -110,17 +112,18 @@ public class MainPresenter extends BasePresenterImpl<MainContract.View> implemen
                 e.onError(new Throwable("已在书架中"));
                 return;
             } else {
-                String baseUrl = StringUtils.getBaseUrl(bookUrl);
+                String fixBookUrl = bookUrl.contains("://") ? bookUrl : "http://"+bookUrl;
+                String baseUrl = new URL(fixBookUrl).getHost();
                 BookSourceBean bookSourceBean = DbHelper.getDaoSession().getBookSourceBeanDao().load(baseUrl);
                 if (bookSourceBean == null) {
                     bookSourceBean = DbHelper.getDaoSession().getBookSourceBeanDao().queryBuilder()
-                            .where(BookSourceBeanDao.Properties.RuleBookUrlPattern.like(baseUrl + "%"))
+                            .where(BookSourceBeanDao.Properties.RuleBookUrlPattern.eq(baseUrl))
                             .limit(1).build().unique();
                 }
                 if (bookSourceBean != null) {
                     BookShelfBean bookShelfBean = new BookShelfBean();
                     bookShelfBean.setTag(bookSourceBean.getBookSourceUrl());
-                    bookShelfBean.setNoteUrl(bookUrl);
+                    bookShelfBean.setNoteUrl(fixBookUrl);
                     bookShelfBean.setDurChapter(0);
                     bookShelfBean.setGroup(mView.getGroup() % 4);
                     bookShelfBean.setDurChapterPage(0);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,7 +334,7 @@
     <string name="rule_search_url">搜索地址(ruleSearchUrl)</string>
     <string name="rule_find_url">发现规则(ruleFindUrl)</string>
     <string name="rule_content_url_next">正文下一页URL规则(ruleContentUrlNext)</string>
-    <string name="book_url_pattern">书籍详情URL正则(ruleBookUrlPattern)</string>
+    <string name="book_url_pattern">书籍详情域名规则(ruleBookUrlPattern)</string>
     <string name="rule_book_kind">分类规则(ruleBookKind)</string>
     <string name="rule_book_last_chapter">最新章节规则(ruleBookLastChapter)</string>
     <string name="source_user_agent">HttpUserAgent</string>


### PR DESCRIPTION
优化书籍详情url正则，规则应只写域名，如规则写`book.qidian.com`，添加网址时填入
[https://book.qidian.com/info/1011449273](https://book.qidian.com/info/1011449273)
或
[http://book.qidian.com/info/1011449273](http://book.qidian.com/info/1011449273)
或
[book.qidian.com/info/1011449273](book.qidian.com/info/1011449273)
均可成功添加书籍。