### PR TITLE
修复一个BUG

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/model/content/BookList.java
+++ b/app/src/main/java/com/kunfei/bookshelf/model/content/BookList.java
@@ -365,7 +365,7 @@ class BookList {
     }
     // 使用正则表达式去除字符串前后的空字符串
     private String regTrim(String str){
-        return str.replaceAll("^[\\n\\s]*|[\\n\\s]*$","");
+        return str.replaceAll("^[\\n\\s]*|[\\n\\s\\\\]*$","");
     }
     // 存取字符串中的put&get参数
     private String checkKeys(String str){


### PR DESCRIPTION
正则表达式匹配的字符串结尾是反斜杠的时候会报告数组下标越界
处理方式为删除掉所有字符串结尾会的反斜杠.