### PR TITLE
修复: 备份文件内容出错

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/utils/DocumentUtil.java
+++ b/app/src/main/java/com/kunfei/bookshelf/utils/DocumentUtil.java
@@ -178,7 +178,7 @@ public class DocumentUtil {
 
     public static boolean writeBytes(Context context, byte[] data, Uri fileUri) {
         try {
-            OutputStream out = context.getContentResolver().openOutputStream(fileUri);
+            OutputStream out = context.getContentResolver().openOutputStream(fileUri, "wt"); //Write file need open with truncate mode, the mode truncate file upon opening (to zero bytes)
             out.write(data);
             out.close();
             return true;


### PR DESCRIPTION
### 问题现象
**复现步骤:**
1. 当`阅读`app存在书源(不仅限于书源)并且已经备份过一次
2. 删除一条书源记录
3. 再次进行备份(此时书源备份文件`myBookSource.json`的格式就已经不正确)
4. 清空所有书源, 然后选择从本地加载之前备份的书源文件或者直接恢复
5. 会报"格式不对"

----

### 产生原因
简单说就是备份时文件的写入操作存在瑕疵.
> **当备份文件已存在内容, 且再次写入的内容比之前的要少, 老内容比新内容多的那部分还会继续保留在文件中.**

---

### 修复方式
打开文件时开启`truncate`模式, truncate模式会先清空再写入
即`wt`模式, `openOutputStream(Uri)`这个API的默认模式是`w`

