### PR TITLE
fix(notification): fix invalid format of WebService URL in traditonal

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -43,7 +43,7 @@
     <string name="retry">重試</string>
     <string name="web_service">web服務</string>
     <string name="web_edit_source">web編輯書源</string>
-    <string name="http_ip">HTTP：//％S：％d</string>
+    <string name="http_ip">http://%s:%d</string>
     <string name="download_offline">離線下載</string>
     <string name="download_offline_t">離線下載</string>
     <string name="download_offline_s">下載選擇的章節到本地</string>


### PR DESCRIPTION
订正繁体下Web服务的通知显示错误：
![image](https://user-images.githubusercontent.com/5202761/73233702-47a9e980-41c2-11ea-9193-9c19c97b9ad0.png)
