### PR TITLE
修复书签列表删除书签时UI不实时刷新的异常

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/view/fragment/BookmarkFragment.java
+++ b/app/src/main/java/com/kunfei/bookshelf/view/fragment/BookmarkFragment.java
@@ -143,8 +143,13 @@ public class BookmarkFragment extends MBaseFragment<IPresenter> {
 
                     @Override
                     public void delBookmark(BookmarkBean bookmarkBean) {
+//                        Log.d("delBookmark","before="+bookmarkBeanList.size());
                         DbHelper.getDaoSession().getBookmarkBeanDao().delete(bookmarkBean);
-                        adapter.notifyDataSetChanged();
+//                        Log.d("delBookmark","after="+bookmarkBeanList.size());
+                        bookmarkBeanList = BookshelfHelp.getBookmarkList(bookShelf.getBookInfoBean().getName());
+//                        Log.d("delBookmark","fine="+bookmarkBeanList.size());
+                        adapter.setAllBookmark(bookmarkBeanList);
+//                        adapter.notifyDataSetChanged();
                     }
 
                     @Override


### PR DESCRIPTION
原方法中的notifyFataSetChanged()并没有实际生效。此PR虽然不优雅不完美，但是粗暴有效。