### PR TITLE
增加3.0书源转2.0的功能

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/bean/BookSource3Bean.java
+++ b/app/src/main/java/com/kunfei/bookshelf/bean/BookSource3Bean.java
@@ -1,0 +1,203 @@
+package com.kunfei.bookshelf.bean;
+
+import android.os.Parcelable;
+
+import com.google.gson.Gson;
+
+import kotlinx.android.parcel.Parcelize;
+
+// 解析阅读3.0的书源规则,toBookSourceBean()方法转换为阅读2.0书源规则
+// https://raw.githubusercontent.com/gedoor/legado/master/app/src/main/java/io/legado/app/data/entities/BookSource.kt
+public class BookSource3Bean {
+    private String bookSourceName = "";                // 名称
+    private String bookSourceGroup;            // 分组
+    private String bookSourceUrl = "";            // 地址，包括 http/https
+    private int bookSourceType = 0;    // 类型，0 文本，1 音频
+    private String bookUrlPattern;            // 详情页url正则
+    private int customOrder = 0;                      // 手动排序编号
+    private Boolean enabled = true;                    // 是否启用
+    private Boolean enabledExplore = true;             // 启用发现
+    private String header;                     // 请求头
+    private String loginUrl;                   // 登录地址
+    private String bookSourceComment;            // 注释
+    private Long lastUpdateTime = 0L;               // 最后更新时间，用于排序
+    private int weight = 0;                            // 智能排序的权重
+    private String exploreUrl;                // 发现url
+    private ExploreRule ruleExplore;          // 发现规则
+    private String searchUrl;                 // 搜索url
+    private SearchRule ruleSearch;             // 搜索规则
+    private BookInfoRule ruleBookInfo;        // 书籍信息页规则
+    private TocRule ruleToc;                 // 目录页规则
+    private ContentRule ruleContent;            // 正文页规则
+
+
+    class ContentRule {
+        String content;
+        String nextContentUrl;
+        String webJs;
+        String sourceRegex;
+        String replaceRegex;
+        String imageStyle;  //默认大小居中,FULL最大宽度
+    }
+
+    class TocRule {
+        String chapterList;
+        String chapterName;
+        String chapterUrl;
+        String isVip;
+        String updateTime;
+        String nextTocUrl;
+    }
+
+    class BookInfoRule {
+        String init;
+        String name;
+        String author;
+        String intro;
+        String kind;
+        String lastChapter;
+        String updateTime;
+        String coverUrl;
+        String tocUrl;
+        String wordCount;
+    }
+
+    class SearchRule {
+        String bookList;
+        String name;
+        String author;
+        String intro;
+        String kind;
+        String lastChapter;
+        String updateTime;
+        String bookUrl;
+        String coverUrl;
+        String wordCount;
+    }
+
+    class ExploreRule {
+        String bookList;
+        String name;
+        String author;
+        String intro;
+        String kind;
+        String lastChapter;
+        String updateTime;
+        String bookUrl;
+        String coverUrl;
+        String wordCount;
+    }
+
+/*    @Override
+    public Object clone() {
+        try {
+            Gson gson = new Gson();
+            String json = gson.toJson(this);
+            return gson.fromJson(json, BookSource3Bean.class);
+        } catch (Exception ignored) {
+        }
+        return this;
+    }*/
+
+    class httpRequest {
+        String method;
+        String body;
+        String headers;
+        String charset;
+    }
+
+    private String searchUrl2RuleSearchUrl(String searchUrl) {
+        String RuleSearchUrl = searchUrl;
+        if (searchUrl != null) {
+            String q = "";
+            if (searchUrl.replaceAll("\\s","").matches("^[^,]+,\\{.+\\}")) {
+                String[] strings = searchUrl.split(",", 2);
+                try {
+                    Gson gson = new Gson();
+                    httpRequest request = gson.fromJson(strings[1], httpRequest.class);
+                    if (request.body != null) {
+                        q = request.body
+                                .replace("{{key}}", "searchKey")
+                                .replaceFirst("\\{\\{([^{}]*)page([^{}]*)\\}\\}", "$1searchPage$2")
+                        ;
+
+                        if (request.charset != null)
+                            q = q + "|char=" + request.charset;
+
+                        if (request.method != null) {
+                            if (request.method.toLowerCase().contains("post"))
+                                q = "@" + q;
+                            else
+                                q = "?" + q;
+                        }
+                        return strings[0] + q;
+                    }
+
+                } catch (Exception ignored) {
+                }
+            }
+
+            return searchUrl
+                    .replace("{{key}}", "searchKey")
+                    .replaceFirst("\\{\\{([^{}]*)page([^{}]*)\\}\\}", "$1searchPage$2")
+                    ;
+        }
+        return null;
+    }
+
+    public BookSourceBean toBookSourceBean() {
+        // 带注释的行，表示2.0/3.0书源json的数据命名不同。注释后方为2.0名称
+        String bookSourceType = "";
+        if (this.bookSourceType != 0)
+            bookSourceType = "" + this.bookSourceType;
+
+        String RuleSearchUrl = searchUrl2RuleSearchUrl(searchUrl);
+
+        return new BookSourceBean(
+                bookSourceUrl,
+                bookSourceName,
+                bookSourceGroup,
+                bookSourceType,
+                loginUrl,
+                lastUpdateTime,
+                0, //u  serialNumber,
+                weight,
+                true, //u enable,
+                exploreUrl,//发现规则 ruleFindUrl,
+                ruleExplore.bookList,  //  列表 ruleFindList,
+                ruleExplore.name,//  ruleFindName,
+                ruleExplore.author,//   ruleFindAuthor,
+                ruleExplore.kind,//  ruleFindKind,
+                ruleExplore.intro,//  ruleFindIntroduce,
+                ruleExplore.lastChapter,//    ruleFindLastChapter,
+                ruleExplore.coverUrl,//   ruleFindCoverUrl,
+                ruleExplore.bookUrl,//???   ruleFindNoteUrl,
+                RuleSearchUrl,//   ruleSearchUrl,
+                ruleSearch.bookList,//  ruleSearchList,
+                ruleSearch.name,// ruleSearchName,
+                ruleSearch.author,// ruleSearchAuthor,
+                ruleSearch.kind,// ruleSearchKind,
+                ruleSearch.intro,// ruleSearchIntroduce,
+                ruleSearch.lastChapter,//  ruleSearchLastChapter,
+                ruleSearch.coverUrl,//ruleSearchCoverUrl,
+                ruleSearch.bookUrl,//  ruleSearchNoteUrl,
+                bookUrlPattern, //???  ruleBookUrlPattern,
+                ruleBookInfo.init,//      ruleBookInfoInit,
+                ruleBookInfo.name,//       ruleBookName,
+                ruleBookInfo.author,//       ruleBookAuthor,
+                ruleBookInfo.coverUrl,//   ruleCoverUrl,
+                ruleBookInfo.intro,//   ruleIntroduce,
+                ruleBookInfo.kind,//   ruleBookKind,
+                ruleBookInfo.lastChapter,//    ruleBookLastChapter,
+                ruleBookInfo.tocUrl,//      ruleChapterUrl,
+                ruleToc.nextTocUrl,//       ruleChapterUrlNext,
+                ruleToc.chapterList,//   ruleChapterList,
+                ruleToc.chapterName,//     ruleChapterName,
+                ruleToc.chapterUrl,  // ruleContentUrl,
+                ruleContent.nextContentUrl, //ruleContentUrlNext,
+                ruleContent.content, //  ruleBookContent,
+                ruleContent.replaceRegex,//    ruleBookContentReplace,
+                header //  httpUserAgent
+        );
+    }
+}

--- a/app/src/main/java/com/kunfei/bookshelf/presenter/SourceEditPresenter.java
+++ b/app/src/main/java/com/kunfei/bookshelf/presenter/SourceEditPresenter.java
@@ -8,14 +8,17 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.kunfei.basemvplib.BasePresenterImpl;
 import com.kunfei.basemvplib.impl.IView;
 import com.kunfei.bookshelf.DbHelper;
+import com.kunfei.bookshelf.bean.BookSource3Bean;
 import com.kunfei.bookshelf.bean.BookSourceBean;
 import com.kunfei.bookshelf.model.BookSourceManager;
 import com.kunfei.bookshelf.presenter.contract.SourceEditContract;
 import com.kunfei.bookshelf.utils.RxUtils;
 
+import java.util.List;
 import java.util.Objects;
 
 import io.reactivex.Observable;
@@ -59,12 +62,89 @@ public class SourceEditPresenter extends BasePresenterImpl<SourceEditContract.Vi
     @Override
     public void setText(String bookSourceStr) {
         try {
-            Gson gson = new Gson();
-            BookSourceBean bookSourceBean = gson.fromJson(bookSourceStr, BookSourceBean.class);
-            mView.setText(bookSourceBean);
+            if (bookSourceStr.trim().length() > 5) {
+                mView.setText( mathcSourceBean(bookSourceStr.trim())  );
+            } else {
+                // 理论上这里已经没用了
+                Gson gson = new Gson();
+                BookSourceBean bookSourceBean = gson.fromJson(bookSourceStr, BookSourceBean.class);
+                mView.setText(bookSourceBean);
+            }
         } catch (Exception e) {
+            if (!setTextV3(bookSourceStr)) {
+                mView.toast("数据格式不对");
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private BookSourceBean mathcSourceBean(String str) {
+        Gson gson = new Gson();
+        BookSource3Bean bookSource3Bean=new BookSource3Bean();
+        BookSourceBean bookSource2Bean=new BookSourceBean();
+        int r2 = 0, r3 = 0;
+        try {
+            if (str.charAt(0) == '[' && str.charAt(str.length() - 1) == ']') {
+                List<BookSource3Bean> list = gson.fromJson(str, new TypeToken<List<BookSource3Bean>>() {
+                }.getType());
+                bookSource3Bean = list.get(0);
+            } else {
+                bookSource3Bean = gson.fromJson(str, BookSource3Bean.class);
+            }
+            r3 = gson.toJson(bookSource3Bean).length();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        try {
+            if (str.charAt(0) == '[' && str.charAt(str.length() - 1) == ']') {
+                List<BookSourceBean> list = gson.fromJson(str, new TypeToken<List<BookSourceBean>>() {
+                }.getType());
+                bookSource2Bean = list.get(0);
+            } else {
+                bookSource2Bean = gson.fromJson(str, BookSourceBean.class);
+            }
+            r2 = gson.toJson(bookSource2Bean).length();
+            if (r2 >= r3)
+                return bookSource2Bean;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if (r3 > 0) {
+            mView.toast("导入了阅读3.0书源。如有Bug请及时上报");
+            return bookSource3Bean.toBookSourceBean();
+        }
+        return bookSource2Bean;
+    }
+
+    // 把阅读v3.0的书源解析并填充到文本框内
+// 输入字符串为多个书源的数组时，只解析第一个源
+    public boolean setTextV3(String bookSourceStr) {
+        try {
+            String str = bookSourceStr.trim();
+            if (str.length() > 5) {
+                Gson gson = new Gson();
+                BookSource3Bean bookSource3Bean;
+
+                if (str.charAt(0) == '[' && str.charAt(str.length() - 1) == ']') {
+                    List<BookSource3Bean> list = gson.fromJson(str, new TypeToken<List<BookSource3Bean>>() {
+                    }.getType());
+                    bookSource3Bean = list.get(0);
+                } else {
+                    bookSource3Bean = gson.fromJson(str, BookSource3Bean.class);
+                }
+
+                mView.setText(bookSource3Bean.toBookSourceBean());
+                mView.toast("导入了阅读3.0书源。如有Bug请及时上报");
+                return true;
+            } else
+                mView.toast("数据格式不对");
+        } catch (Exception e) {
+            e.printStackTrace();
             mView.toast("数据格式不对");
         }
+        return false;
     }
 
     @Override

--- a/app/src/main/java/com/kunfei/bookshelf/view/activity/SourceEditActivity.java
+++ b/app/src/main/java/com/kunfei/bookshelf/view/activity/SourceEditActivity.java
@@ -107,7 +107,7 @@ public class SourceEditActivity extends MBaseActivity<SourceEditContract.Present
     private PopupWindow mSoftKeyboardTool;
     private boolean mIsSoftKeyBoardShowing = false;
     private boolean showFind;
-    private String[] keyHelp = {"@", "&", "|", "%", "/", ":", "[", "]", "{", "}", "<", ">", "\\", "$", "#", "!", ".",
+    private String[] keyHelp = {"@", "&", "|", "%", "/", ":", "[", "]", "(", ")", "{", "}", "<", ">", "\\", "$", "#", "!", ".",
             "href", "src", "textNodes", "xpath", "json", "css", "id", "class", "tag"};
 
     public static void startThis(Object object, BookSourceBean sourceBean) {


### PR DESCRIPTION
1. 在编辑书源界面，如粘贴阅读3.0书源，会自动转换为阅读2.0书源。此转换功能兼容性有限，仅为缩短制作2.0书源的时间。如果发现bug，请明确指出3.0书源的条目名称、填入的字符串、转换为2.0的条目名称、错误字符串分别是什么，而正确字符串又是什么。  
2. 解决了粘贴书源json字符串最外层有[]时，无法正常解析的问题