### PR TITLE
增加复制小说网址、广告话术规则的功能，优化书源管理、替换规则管理、自动分段算法

### DIFF
--- a/app/src/main/java/com/kunfei/bookshelf/bean/BookInfoBean.java
+++ b/app/src/main/java/com/kunfei/bookshelf/bean/BookInfoBean.java
@@ -38,7 +38,7 @@ public class BookInfoBean implements Cloneable {
     private String chapterUrl;  //章节目录地址,本地目录正则
     private long finalRefreshData;  //章节最后更新时间
     private String coverUrl; //小说封面
-    private String author;//作者
+    private String author="";//作者
     private String introduce; //简介
     private String origin; //来源
     private String charset;//编码

--- a/app/src/main/java/com/kunfei/bookshelf/bean/BookSource3Bean.java
+++ b/app/src/main/java/com/kunfei/bookshelf/bean/BookSource3Bean.java
@@ -143,7 +143,7 @@ public class BookSource3Bean {
                     Gson gson = new Gson();
                     httpRequest request = gson.fromJson(strings[1], httpRequest.class);
                     if (gson.toJson(request).replaceAll("\\s", "").length() > 0) {
-                        // 阅读2.0没有header，只有useragent
+                        // 阅读2.0没有单独的header，只有useragent
                         if (request.headers != null) {
                             if (this.header == null)
                                 this.header = request.headers;
@@ -208,6 +208,14 @@ public class BookSource3Bean {
             ruleFindUrl=exploreUrl.replaceAll("\\{\\{page\\}\\}","searchPage");
         }
 
+        // 暂时只给发现和搜索添加了header
+        String header="";
+        if(this.header!=null){
+            if(this.header.trim().length()>0)
+            header="@Header:"+this.header.replaceAll("\\n"," ");
+        }
+
+
         return new BookSourceBean(
                 bookSourceUrl,
                 bookSourceName,
@@ -218,7 +226,7 @@ public class BookSource3Bean {
                 0, //u  serialNumber,
                 weight,
                 true, //u enable,
-                ruleFindUrl,//发现规则 ruleFindUrl,
+                ruleFindUrl+header,//发现规则 ruleFindUrl,
                 ruleExplore.bookList,  //  列表 ruleFindList,
                 ruleExplore.name,//  ruleFindName,
                 ruleExplore.author,//   ruleFindAuthor,
@@ -227,7 +235,7 @@ public class BookSource3Bean {
                 ruleExplore.lastChapter,//    ruleFindLastChapter,
                 ruleExplore.coverUrl,//   ruleFindCoverUrl,
                 ruleExplore.bookUrl,//???   ruleFindNoteUrl,
-                RuleSearchUrl,//   ruleSearchUrl,
+                RuleSearchUrl+header,//   ruleSearchUrl,
                 ruleSearch.bookList,//  ruleSearchList,
                 ruleSearch.name,// ruleSearchName,
                 ruleSearch.author,// ruleSearchAuthor,

--- a/app/src/main/java/com/kunfei/bookshelf/model/ReplaceRuleManager.java
+++ b/app/src/main/java/com/kunfei/bookshelf/model/ReplaceRuleManager.java
@@ -13,6 +13,9 @@ import com.kunfei.bookshelf.utils.NetworkUtils;
 import com.kunfei.bookshelf.utils.RxUtils;
 import com.kunfei.bookshelf.utils.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import io.reactivex.Observable;
@@ -36,6 +39,95 @@ public class ReplaceRuleManager {
                     .list();
         }
         return replaceRuleBeansEnabled;
+    }
+
+    // 合并广告话术规则
+    public static Single<Boolean> mergeAdRules(ReplaceRuleBean replaceRuleBean) {
+
+
+        String rule = formateAdRule(replaceRuleBean.getRegex());
+
+/*        String summary=replaceRuleBean.getReplaceSummary();
+        if(summary==null)
+            summary="";
+        String sumary_pre=summary.split("-")[0];*/
+
+        int sn = replaceRuleBean.getSerialNumber();
+        if (sn == 0) {
+            sn = (int) (DbHelper.getDaoSession().getReplaceRuleBeanDao().queryBuilder().count() + 1);
+            replaceRuleBean.setSerialNumber(sn);
+        }
+
+        List<ReplaceRuleBean> list = DbHelper.getDaoSession()
+                .getReplaceRuleBeanDao().queryBuilder()
+                .where(ReplaceRuleBeanDao.Properties.Enable.eq(true))
+                .where(ReplaceRuleBeanDao.Properties.ReplaceSummary.eq(replaceRuleBean.getReplaceSummary()))
+                .where(ReplaceRuleBeanDao.Properties.SerialNumber.notEq(sn))
+                .orderAsc(ReplaceRuleBeanDao.Properties.SerialNumber)
+                .list();
+        if (list.size() < 1) {
+            replaceRuleBean.setRegex(rule);
+            return saveData(replaceRuleBean);
+        } else {
+            StringBuffer buffer = new StringBuffer(rule);
+            for (ReplaceRuleBean li : list) {
+                buffer.append('\n');
+                buffer.append(li.getRegex());
+//                    buffer.append(formateAdRule(rule.getRegex()));
+            }
+            replaceRuleBean.setRegex(formateAdRule(buffer.toString()));
+
+            return Single.create((SingleOnSubscribe<Boolean>) emitter -> {
+
+                DbHelper.getDaoSession().getReplaceRuleBeanDao().insertOrReplace(replaceRuleBean);
+                for (ReplaceRuleBean li : list) {
+                    DbHelper.getDaoSession().getReplaceRuleBeanDao().delete(li);
+                }
+                refreshDataS();
+                emitter.onSuccess(true);
+            }).compose(RxUtils::toSimpleSingle);
+
+        }
+    }
+
+    // 把输入的规则进行预处理（分段、排序、去重）。保存的是普通多行文本。
+    public static String formateAdRule(String rule) {
+
+        if (rule == null)
+            return "";
+        String result = rule.trim();
+        if (result.length() < 1)
+            return "";
+
+        String string = rule
+//                用中文中的.视为。进行分段
+                .replaceAll("(?<=([^a-zA-Z\\p{P}]{4,8}))\\.+(?![^a-zA-Z\\p{P}]{4,8})","\n")
+//                用常见的适合分段的标点进行分段，句首句尾除外
+//                .replaceAll("([^\\p{P}\n^])([…,，:：？。！?!~<>《》【】（）()]+)([^\\p{P}\n$])", "$1\n$3")
+//                表达式无法解决句尾连续多个符号的问题
+//                .replaceAll("[…,，:：？。！?!~<>《》【】（）()]+(?!\\s*\n|$)", "\n")
+                .replaceAll("(?<![\\p{P}\n^])([…,，:：？。！?!~<>《》【】（）()]+)(?![\\p{P}\n$])", "\n")
+
+                ;
+
+        String[] lines = string.split("\n");
+        List<String> list = new ArrayList<>();
+
+        for (String s : lines) {
+            s = s.trim()
+//                    .replaceAll("\\s+", "\\s")
+            ;
+            if (!list.contains(s)) {
+                list.add(s);
+            }
+        }
+        Collections.sort(list);
+        StringBuffer buffer = new StringBuffer(rule.length() + 1);
+        for (int i = 0; i < list.size(); i++) {
+            buffer.append('\n');
+            buffer.append(list.get(i));
+        }
+        return buffer.toString().trim();
     }
 
     public static Single<List<ReplaceRuleBean>> getAll() {

--- a/app/src/main/java/com/kunfei/bookshelf/presenter/BookSourcePresenter.java
+++ b/app/src/main/java/com/kunfei/bookshelf/presenter/BookSourcePresenter.java
@@ -191,6 +191,41 @@ public class BookSourcePresenter extends BasePresenterImpl<BookSourceContract.Vi
         CheckSourceService.start(mView.getContext(), sourceBeans);
     }
 
+    @Override
+    public void checkFindSource(List<BookSourceBean> sourceBeans) {
+        String TAG_FIND_SOUECE="发现";
+
+        Observable.create((ObservableOnSubscribe<Boolean>) e -> {
+            for (BookSourceBean sourceBean : sourceBeans) {
+                String rule=sourceBean.getRuleFindUrl();
+                if(rule==null)
+                    sourceBean.removeGroup(TAG_FIND_SOUECE);
+                else if(rule.trim().length()<1){
+                    sourceBean.removeGroup(TAG_FIND_SOUECE);
+                    sourceBean.setRuleFindUrl(null);
+                }else{
+                    sourceBean.addGroup(TAG_FIND_SOUECE);
+                }
+                DbHelper.getDaoSession().getBookSourceBeanDao().insertOrReplaceInTx(sourceBean);
+            }
+            e.onNext(true);
+        }).subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(new MyObserver<Boolean>() {
+                    @Override
+                    public void onNext(Boolean aBoolean) {
+                        mView.toast(TAG_FIND_SOUECE+"标签验校完成");
+                        mView.refreshBookSource();
+                        mView.setResult(RESULT_OK);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        mView.toast("验校失败");
+                    }
+                });
+    }
+
     /////////////////////////////////////////////////
 
     @Override

--- a/app/src/main/java/com/kunfei/bookshelf/presenter/contract/BookSourceContract.java
+++ b/app/src/main/java/com/kunfei/bookshelf/presenter/contract/BookSourceContract.java
@@ -25,6 +25,7 @@ public interface BookSourceContract {
 
         void checkBookSource(List<BookSourceBean> sourceBeans);
 
+        void checkFindSource(List<BookSourceBean> sourceBeans);
     }
 
     interface View extends IView {

--- a/app/src/main/java/com/kunfei/bookshelf/view/activity/BookDetailActivity.java
+++ b/app/src/main/java/com/kunfei/bookshelf/view/activity/BookDetailActivity.java
@@ -2,6 +2,9 @@
 package com.kunfei.bookshelf.view.activity;
 
 import android.annotation.SuppressLint;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
@@ -434,6 +437,9 @@ public class BookDetailActivity extends MBaseActivity<BookDetailContract.Present
             if (!mPresenter.getBookShelf().getTag().equals(BookShelfBean.LOCAL_TAG)) {
                 popupMenu.getMenu().add(Menu.NONE, R.id.menu_edit, Menu.NONE, R.string.edit_book_source);
             }
+            if (!mPresenter.getBookShelf().getTag().equals(BookShelfBean.LOCAL_TAG)) {
+                popupMenu.getMenu().add(Menu.NONE, R.id.menu_copy_url, Menu.NONE, R.string.copy_url);
+            }
             popupMenu.setOnMenuItemClickListener(menuItem -> {
                 switch (menuItem.getItemId()) {
                     case R.id.menu_refresh:
@@ -451,6 +457,14 @@ public class BookDetailActivity extends MBaseActivity<BookDetailContract.Present
                         BookSourceBean sourceBean = BookSourceManager.getBookSourceByUrl(mPresenter.getBookShelf().getTag());
                         if (sourceBean != null) {
                             SourceEditActivity.startThis(this, sourceBean);
+                        }
+                        break;
+                    case R.id.menu_copy_url:
+                        ClipboardManager clipboard = (ClipboardManager) this.getSystemService(Context.CLIPBOARD_SERVICE);
+                        ClipData clipData = ClipData.newPlainText(null, mPresenter.getBookShelf().getNoteUrl());
+                        if (clipboard != null) {
+                            clipboard.setPrimaryClip(clipData);
+                            toast(R.string.copy_complete);
                         }
                         break;
                 }

--- a/app/src/main/java/com/kunfei/bookshelf/view/activity/BookSourceActivity.java
+++ b/app/src/main/java/com/kunfei/bookshelf/view/activity/BookSourceActivity.java
@@ -301,6 +301,9 @@ public class BookSourceActivity extends MBaseActivity<BookSourceContract.Present
             case R.id.action_check_book_source:
                 mPresenter.checkBookSource(adapter.getSelectDataList());
                 break;
+            case R.id.action_check_find_source:
+                mPresenter.checkFindSource(adapter.getSelectDataList());
+                break;
             case R.id.sort_manual:
                 upSourceSort(0);
                 break;

--- a/app/src/main/java/com/kunfei/bookshelf/view/popupwindow/ReadLongPressPop.java
+++ b/app/src/main/java/com/kunfei/bookshelf/view/popupwindow/ReadLongPressPop.java
@@ -28,6 +28,8 @@ public class ReadLongPressPop extends FrameLayout {
     FrameLayout flReplace;
     @BindView(R.id.fl_cp)
     FrameLayout flCp;
+    @BindView(R.id.fl_replace_ad)
+    FrameLayout flReplaceAd;
 
 
     //private ReadBookActivity activity;
@@ -82,17 +84,22 @@ public class ReadLongPressPop extends FrameLayout {
 
     private void bindEvent() {
 
-        //翻页1
+        //复制
         flCp.setOnClickListener(v -> clickListener.copySelect());
 
-        //翻页2
+        //替换
         flReplace.setOnClickListener(v -> clickListener.replaceSelect());
+
+        //标记广告
+        flReplaceAd.setOnClickListener(v -> clickListener.replaceSelectAd());
     }
 
     public interface OnBtnClickListener {
         void copySelect();
 
         void replaceSelect();
+
+        void replaceSelectAd();
 
     }
 }

--- a/app/src/main/java/com/kunfei/bookshelf/widget/modialog/ReplaceRuleDialog.java
+++ b/app/src/main/java/com/kunfei/bookshelf/widget/modialog/ReplaceRuleDialog.java
@@ -3,8 +3,10 @@ package com.kunfei.bookshelf.widget.modialog;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
@@ -27,6 +29,20 @@ public class ReplaceRuleDialog extends BaseDialog {
     private ReplaceRuleBean replaceRuleBean;
     private BookShelfBean bookShelfBean;
 
+    private TextView replace_ad_intro, tvtitle;
+    private View til_replace_to;
+
+    // 替换规则编辑UI的模式  1 默认  2 广告话术  3 添加广告话术
+    private int ReplaceUIMode = 1;
+    public static int DefaultUI = 1, AdUI = 2, AddAdUI = 3;
+    private String str_summary = "";
+
+
+    public static ReplaceRuleDialog builder(Context context, ReplaceRuleBean replaceRuleBean, BookShelfBean bookShelfBean, int replaceUIMode) {
+        return new ReplaceRuleDialog(context, replaceRuleBean, bookShelfBean, replaceUIMode);
+    }
+
+
     public static ReplaceRuleDialog builder(Context context, ReplaceRuleBean replaceRuleBean, BookShelfBean bookShelfBean) {
         return new ReplaceRuleDialog(context, replaceRuleBean, bookShelfBean);
     }
@@ -36,6 +52,19 @@ public class ReplaceRuleDialog extends BaseDialog {
         this.context = context;
         this.replaceRuleBean = replaceRuleBean;
         this.bookShelfBean = bookShelfBean;
+
+        @SuppressLint("InflateParams") View view = LayoutInflater.from(context).inflate(R.layout.dialog_replace_rule, null);
+        bindView(view);
+        setContentView(view);
+
+    }
+
+    private ReplaceRuleDialog(Context context, ReplaceRuleBean replaceRuleBean, BookShelfBean bookShelfBean, int replaceUIMod) {
+        super(context, R.style.alertDialogTheme);
+        this.context = context;
+        this.replaceRuleBean = replaceRuleBean;
+        this.bookShelfBean = bookShelfBean;
+        this.ReplaceUIMode = replaceUIMod;
 
         @SuppressLint("InflateParams") View view = LayoutInflater.from(context).inflate(R.layout.dialog_replace_rule, null);
         bindView(view);
@@ -52,12 +81,64 @@ public class ReplaceRuleDialog extends BaseDialog {
         tieUseTo = view.findViewById(R.id.tie_use_to);
         cbUseRegex = view.findViewById(R.id.cb_use_regex);
         tvOk = view.findViewById(R.id.tv_ok);
+        replace_ad_intro = view.findViewById(R.id.replace_ad_intro);
+        tvtitle = view.findViewById(R.id.title);
+        til_replace_to=view.findViewById(R.id.til_replace_to);
         if (replaceRuleBean != null) {
             tieReplaceSummary.setText(replaceRuleBean.getReplaceSummary());
             tieReplaceTo.setText(replaceRuleBean.getReplacement());
             tieReplaceRule.setText(replaceRuleBean.getRegex());
             tieUseTo.setText(replaceRuleBean.getUseTo());
             cbUseRegex.setChecked(replaceRuleBean.getIsRegex());
+
+            // 初始化广告话术规则的UI
+            if (ReplaceUIMode == DefaultUI) {
+                if (replaceRuleBean.getReplaceSummary().matches("^" + view.getContext().getString(R.string.replace_ad) + ".*"))
+                    ReplaceUIMode = AdUI;
+            }
+            if (ReplaceUIMode > DefaultUI) {
+//                tieReplaceTo.setVisibility(View.GONE);
+                til_replace_to.setVisibility(View.GONE);
+                cbUseRegex.setVisibility(View.GONE);
+                replace_ad_intro.setVisibility(View.VISIBLE);
+                tieReplaceSummary.setInputType(EditorInfo.TYPE_NULL);
+                tieReplaceRule.setMaxLines(8);
+
+                if (ReplaceUIMode == AdUI) {
+                    tvtitle.setText(view.getContext().getString(R.string.replace_ad_title));
+                } else {
+                    tvtitle.setText(view.getContext().getString(R.string.replace_add_ad_title));
+                }
+                str_summary = view.getContext().getString(R.string.replace_ad);
+                TextWatcher mTextWatcher = new TextWatcher() {
+                    private CharSequence temp;
+
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {
+                        temp = s;
+                        String str=s.toString().trim();
+                        if (str.replaceAll("[\\s,]", "").length() > 0)
+                            tieReplaceSummary.setText(str_summary + "-" + str);
+                        else
+                            tieReplaceSummary.setText(str_summary);
+                    }
+
+                    @Override
+                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+                    }
+
+                    @Override
+                    public void afterTextChanged(Editable s) {
+/*                        if (s.toString().replaceAll("[\\s,]", "").length() > 0)
+                            tieReplaceSummary.setText(str_summary + "-" + temp);
+                        else
+                            tieReplaceSummary.setText(str_summary);*/
+                    }
+                };
+                tieUseTo.addTextChangedListener(mTextWatcher);
+
+            }
         } else {
             replaceRuleBean = new ReplaceRuleBean();
             replaceRuleBean.setEnable(true);
@@ -66,7 +147,9 @@ public class ReplaceRuleDialog extends BaseDialog {
                 tieUseTo.setText(String.format("%s,%s", bookShelfBean.getBookInfoBean().getName(), bookShelfBean.getTag()));
             }
         }
+
     }
+
 
     public ReplaceRuleDialog setPositiveButton(Callback callback) {
         tvOk.setOnClickListener(v -> {
@@ -91,5 +174,6 @@ public class ReplaceRuleDialog extends BaseDialog {
     public interface Callback {
         void onPositiveButton(ReplaceRuleBean replaceRuleBean);
     }
+
 
 }

--- a/app/src/main/java/com/kunfei/bookshelf/widget/page/ChapterProvider.java
+++ b/app/src/main/java/com/kunfei/bookshelf/widget/page/ChapterProvider.java
@@ -69,12 +69,17 @@ class ChapterProvider {
             txtChapter.addPage(page);
             return txtChapter;
         }
+        Log.i("content-1",chapter.getDurChapterName()+"\n"+content.substring(content.length()/3*2));
         content = contentHelper.replaceContent(pageLoader.book.getBookInfoBean().getName(), pageLoader.book.getTag(), content, pageLoader.book.getReplaceEnable());
-//        Log.i("content",content);
+
 //        Log.i("chapterName",chapter.getDurChapterName());
 //      方便debug
-//        if(chapter.getDurChapterName().matches(".*宣战.*"))
+//        if(chapter.getDurChapterName().matches(".*幽魂.*"))
+        {
+//               Log.i("content",content);
+
         content = contentHelper.LightNovelParagraph2(content,chapter.getDurChapterName());
+        }
         String[] allLine = content.split("\n");
         List<String> lines = new ArrayList<>();
         List<TxtLine> txtLists = new ArrayList<>();//记录每个字的位置 //pzl

--- a/app/src/main/java/com/kunfei/bookshelf/widget/page/PageView.java
+++ b/app/src/main/java/com/kunfei/bookshelf/widget/page/PageView.java
@@ -436,8 +436,8 @@ public class PageView extends View implements PageAnimation.OnPageChangeListener
                 RectF rect = new RectF(fistchar.getTopLeftPosition().x, fistchar.getTopLeftPosition().y,
                         lastchar.getTopRightPosition().x, lastchar.getBottomRightPosition().y);
 
-                canvas.drawRoundRect(rect, fw / 2,
-                        textHeight / 2, mTextSelectPaint);
+                canvas.drawRoundRect(rect, fw / 4,
+                        textHeight /4, mTextSelectPaint);
             }
         }
     }

--- a/app/src/main/res/drawable/ic_baseline_label.xml
+++ b/app/src/main/res/drawable/ic_baseline_label.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17.63,5.84C17.27,5.33 16.67,5 16,5L5,5.01C3.9,5.01 3,5.9 3,7v10c0,1.1 0.9,1.99 2,1.99L16,19c0.67,0 1.27,-0.33 1.63,-0.84L22,12l-4.37,-6.16z"/>
+</vector>

--- a/app/src/main/res/layout/activity_book_read.xml
+++ b/app/src/main/res/layout/activity_book_read.xml
@@ -50,7 +50,7 @@
 
     <com.kunfei.bookshelf.view.popupwindow.ReadLongPressPop
         android:id="@+id/readLongPress"
-        android:layout_width="120dp"
+        android:layout_width="190dp"
         android:layout_height="30dp"
         android:layout_gravity="center"
         android:visibility="invisible" />

--- a/app/src/main/res/layout/dialog_replace_rule.xml
+++ b/app/src/main/res/layout/dialog_replace_rule.xml
@@ -12,6 +12,7 @@
         android:padding="10dp">
 
         <TextView
+            android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -76,6 +77,16 @@
                 android:layout_height="wrap_content"
                 android:maxLines="3" />
         </com.kunfei.bookshelf.widget.views.ATETextInputLayout>
+
+        <TextView
+            android:id="@+id/replace_ad_intro"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="10dp"
+            android:text="@string/replace_ad_intro"
+            android:textSize="16sp"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/tv_ok"

--- a/app/src/main/res/layout/pop_read_long_press.xml
+++ b/app/src/main/res/layout/pop_read_long_press.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="120dp"
+    android:layout_width="190dp"
     android:layout_height="30dp"
     android:layout_gravity="center_horizontal"
     android:alpha="0.9"
     android:background="#000000"
     android:clickable="true"
-    android:orientation="vertical"
-    android:focusable="true">
+    android:focusable="true"
+    android:orientation="vertical">
 
     <LinearLayout
-        android:layout_width="120dp"
+        android:layout_width="match_parent"
         android:layout_height="30dp"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="0.0dip"
@@ -21,18 +21,17 @@
 
         <FrameLayout
             android:id="@+id/fl_cp"
-            android:layout_width="fill_parent"
-            android:layout_height="32.0dip"
-            android:layout_marginLeft="4.0dip"
-            android:layout_marginRight="4.0dip"
-            android:layout_weight="50.0"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
             android:paddingLeft="4.0dip"
             android:paddingRight="4.0dip">
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:gravity="center"
                 android:text="复制"
                 android:textColor="#ffbbbbbb"
                 android:textSize="14sp" />
@@ -42,19 +41,37 @@
 
         <FrameLayout
             android:id="@+id/fl_replace"
-            android:layout_width="fill_parent"
-            android:layout_height="32.0dip"
-            android:layout_marginLeft="4.0dip"
-            android:layout_marginRight="4.0dip"
-            android:layout_weight="50.0"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
             android:paddingLeft="4.0dip"
             android:paddingRight="4.0dip">
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:gravity="center"
                 android:text="替换"
+                android:textColor="#ffbbbbbb"
+                android:textSize="14sp" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/fl_replace_ad"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:paddingLeft="4.0dip"
+            android:paddingRight="4.0dip">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:text="广告"
                 android:textColor="#ffbbbbbb"
                 android:textSize="14sp" />
 

--- a/app/src/main/res/menu/menu_book_source_activity.xml
+++ b/app/src/main/res/menu/menu_book_source_activity.xml
@@ -95,6 +95,11 @@
         android:icon="@drawable/ic_check_source"
         android:title="@string/check_select_source"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_check_find_source"
+        android:icon="@drawable/ic_baseline_label"
+        android:title="@string/check_find_source"
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/action_share_wifi"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -23,4 +23,6 @@
 
     <item name="menu_disable" type="id" />
 
+    <item name="menu_copy_url" type="id"/>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,4 +478,10 @@
     <string name="light_novel_paragraph">自动重分段落</string>
     <string name="share_book">分享书籍</string>
     <string name="add_qrcode">扫二维码</string>
+    <string name="copy_url">复制网址</string>
+    <string name="check_find_source">标记所选发现源</string>
+    <string name="replace_ad">广告话术</string>
+    <string name="replace_ad_title">编辑广告话术规则</string>
+    <string name="replace_add_ad_title">添加广告话术规则</string>
+    <string name="replace_ad_intro">广告话术功能使用了自动优化的算法，不需要使用正则表达式，只需要多次标记不想看的文字，就可以获得较好的广告替换效果。同一个网站的广告话术自动保存在一个规则内，避免了“替换净化”列表里有太多多的规则。</string>
 </resources>


### PR DESCRIPTION
1.在书架查看书籍的界面，增加复制小说网址的菜单。
2.在书源列表界面，增加检查书源是否包含发现规则，并增加/删除“发现”标签的功能。
3.在阅读界面，增加长按按钮“广告”，可以快速把正文添加到命名为“广告话术-xxx网址”的规则中去。针对此规则，使用了专门的增强算法。只需要多次标记不想看的文字，就可以获得较好的广告替换效果。用户不需要熟悉正则语法，不需要维护复杂的规则。同一个网站的广告话术自动保存在一个规则内，避免了“替换净化”列表里有太多多的规则。
4.在阅读界面，优化长按按钮“替换”，自动添加书名、网址到应用范围中。
5.进一步优化自动分段算法